### PR TITLE
Support CV vector base conversion to/from a guid format

### DIFF
--- a/src/Microsoft.CorrelationVector.UnitTests/CorrelationVectorTests.cs
+++ b/src/Microsoft.CorrelationVector.UnitTests/CorrelationVectorTests.cs
@@ -56,7 +56,16 @@ namespace Microsoft.CorrelationVector.UnitTests
         }
 
         [TestMethod]
-        public void GetBaseAsGuidTest()
+        public void GetBaseAsGuidV1Test()
+        {
+            var correlationVector = new CorrelationVector(CorrelationVectorVersion.V1);
+
+            Assert.ThrowsException<InvalidOperationException>(() => correlationVector.GetBaseAsGuid(),
+                "V1 correlation vector base cannot be converted to a guid");
+        }
+
+        [TestMethod]
+        public void GetBaseAsGuidV2Test()
         {
             var guid = System.Guid.NewGuid();
             var correlationVector = new CorrelationVector(guid);
@@ -116,7 +125,7 @@ namespace Microsoft.CorrelationVector.UnitTests
                 var correlationVectorFromGuid = new CorrelationVector(baseAsGuid);
 
                 Assert.AreEqual(correlationVector.Value, correlationVectorFromGuid.Value,
-                    $"Correlation vector base -> guid -> correlation vector base should result in the same vector for {vectorBase}");
+                    $"Correlation vector base -> guid -> correlation vector base should result in the same vector base for {vectorBase}");
             }
         }
 

--- a/src/Microsoft.CorrelationVector/CorrelationVector.cs
+++ b/src/Microsoft.CorrelationVector/CorrelationVector.cs
@@ -221,6 +221,51 @@ namespace Microsoft.CorrelationVector
         }
 
         /// <summary>
+        /// Gets an encoded vector base value from the given <see cref="Guid"/>.
+        /// </summary>
+        /// <param name="guid">The <see cref="Guid"/> to encode as a vector base.</param>
+        /// <returns>The encoded vector base value.</returns>
+        public static string GetBaseFromGuid(Guid guid)
+        {
+            byte[] bytes = guid.ToByteArray();
+
+            // Removes the base64 padding
+            return Convert.ToBase64String(bytes).Substring(0, CorrelationVector.BaseLengthV2);
+        }
+
+        /// <summary>
+        /// Gets the value of the correlation vector base encoded as a <see cref="Guid"/>.
+        /// </summary>
+        /// <returns>The <see cref="Guid"/> value of the encoded vector base.</returns>
+        public Guid GetBaseAsGuid()
+        {
+            if (this.Version == CorrelationVectorVersion.V1)
+            {
+                throw new InvalidOperationException("Cannot convert a V1 correlation vector base to a guid.");
+            }
+
+            if (ValidateCorrelationVectorDuringCreation)
+            {
+                // In order to reliably convert a V2 vector base to a guid, the four least significant bits of the last
+                // base64 content-bearing 6-bit block must be zeros.
+                // There are four such base64 characters so we can easily detect whether this condition is true.
+                // A - 00 0000
+                // Q - 01 0000
+                // g - 10 0000
+                // w - 11 0000
+                char lastChar = this.baseVector[BaseLengthV2 - 1];
+
+                if (lastChar != 'A' && lastChar != 'Q' && lastChar != 'g' && lastChar != 'w')
+                {
+                    throw new InvalidOperationException(
+                        "The four least significant bits of the base64 encoded vector base must be zeros to reliably convert to a guid.");
+                }
+            }
+
+            return new Guid(Convert.FromBase64String(this.baseVector + "=="));
+        }
+
+        /// <summary>
         /// Increments the current extension by one. Do this before passing the value to an
         /// outbound message header.
         /// </summary>
@@ -294,14 +339,6 @@ namespace Microsoft.CorrelationVector
             this.extension = extension;
             this.Version = version;
             this.immutable = immutable || CorrelationVector.IsOversized(baseVector, extension, version);
-        }
-
-        private static string GetBaseFromGuid(Guid guid)
-        {
-            byte[] bytes = guid.ToByteArray();
-
-            // Removes the base64 padding
-            return Convert.ToBase64String(bytes).Substring(0, CorrelationVector.BaseLengthV2);
         }
 
         private static string GetUniqueValue(CorrelationVectorVersion version)

--- a/src/Microsoft.CorrelationVector/CorrelationVectorExtensions.cs
+++ b/src/Microsoft.CorrelationVector/CorrelationVectorExtensions.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.CorrelationVector
+{
+    /// <summary>
+    /// Extensions methods providing additional functionality for correlation vectors.
+    /// </summary>
+    public static class CorrelationVectorExtensions
+    {
+        /// <summary>
+        /// Gets an encoded vector base value from the <see cref="Guid"/>.
+        /// </summary>
+        /// <param name="guid">The <see cref="Guid"/> to encode as a vector base.</param>
+        /// <returns>The encoded vector base value.</returns>
+        public static string GetBaseFromGuid(this Guid guid)
+        {
+            byte[] bytes = guid.ToByteArray();
+
+            // Removes the base64 padding
+            return Convert.ToBase64String(bytes).Substring(0, CorrelationVector.BaseLengthV2);
+        }
+
+        /// <summary>
+        /// Gets the value of the correlation vector base encoded as a <see cref="Guid"/>.
+        /// </summary>
+        /// <returns>The <see cref="Guid"/> value of the encoded vector base.</returns>
+        public static Guid GetBaseAsGuid(this CorrelationVector correlationVector)
+        {
+            if (correlationVector.Version == CorrelationVectorVersion.V1)
+            {
+                throw new InvalidOperationException("Cannot convert a V1 correlation vector base to a guid.");
+            }
+
+            if (CorrelationVector.ValidateCorrelationVectorDuringCreation)
+            {
+                // In order to reliably convert a V2 vector base to a guid, the four least significant bits of the last
+                // base64 content-bearing 6-bit block must be zeros.
+                // There are four such base64 characters so we can easily detect whether this condition is true.
+                // A - 00 0000
+                // Q - 01 0000
+                // g - 10 0000
+                // w - 11 0000
+                char lastChar = correlationVector.BaseVector[CorrelationVector.BaseLengthV2 - 1];
+
+                if (lastChar != 'A' && lastChar != 'Q' && lastChar != 'g' && lastChar != 'w')
+                {
+                    throw new InvalidOperationException(
+                        "The four least significant bits of the base64 encoded vector base must be zeros to reliably convert to a guid.");
+                }
+            }
+
+            return new Guid(Convert.FromBase64String(correlationVector.BaseVector + "=="));
+        }
+    }
+}


### PR DESCRIPTION
Add functionality to the CorrelationVector class to convert a V2 base64 encoded vector base to/from a guid format.